### PR TITLE
Fix format - replace '\t' by four space

### DIFF
--- a/src/hcsr04.h
+++ b/src/hcsr04.h
@@ -7,7 +7,7 @@ class HCSR04
 {
   public:
     HCSR04(int trigger, int echo);
-	HCSR04(int trigger, int echo, int minRange, int maxRange);
+    HCSR04(int trigger, int echo, int minRange, int maxRange);
     unsigned int echoInMicroseconds();
     int distanceInMillimeters();
     void ToSerial();
@@ -15,8 +15,8 @@ class HCSR04
   private:
     int _trigger;
     int _echo;
-	int _minRange = -1;
-	int _maxRange = -1;
+    int _minRange = -1;
+    int _maxRange = -1;
 };
 
 #endif


### PR DESCRIPTION
Original:
```
有时候，'\t'会被错误地渲染为八个空格的大小，为了让代码看起来不那么奇怪，我用四个空格替换了'\t'

英文不是很好，十分抱歉。
```
Translated by Google and me:
```
Sometimes, '\t' would display like night space(' '). To make the code look less strange, I replace '\t' with four space.

Bad English, I'm very sorry.
```